### PR TITLE
Bump agent version to v2.1.26

### DIFF
--- a/.github/actions/install-helm-chart/action.yml
+++ b/.github/actions/install-helm-chart/action.yml
@@ -16,6 +16,11 @@ inputs:
     description: "How many seconds to sleep / wait after the pod has been started up for initial ingestion"
     required: true
     default: 20
+  image_type:
+    description: "Docker image type to use (buster, alpine)"
+    required: true
+    default: "buster"
+
 
 runs:
   using: "composite"
@@ -25,6 +30,9 @@ runs:
       run: |
         # Set write API key
         sed -i "s#REPLACE_ME#${{ inputs.scalyr_api_key }}#g" "${{ inputs.values_file_path }}"
+
+        # Set image type
+        sed -i "s#IMAGE_TYPE#${{ inputs.image_type }}#g" "${{ inputs.values_file_path }}"
 
         # Install chart
         helm install --debug --wait --values "${{ inputs.values_file_path }}" scalyr-agent charts/scalyr-agent

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -30,7 +30,7 @@ jobs:
           github_token: ${{ github.token }}
 
   daemonset_controller_type:
-    name: Daemonset - k8s ${{ matrix.k8s_version }} ${{ matrix.image_type }}
+    name: Daemonset - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
 
     needs: pre_job

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -30,7 +30,7 @@ jobs:
           github_token: ${{ github.token }}
 
   daemonset_controller_type:
-    name: Daemonset - k8s ${{ matrix.k8s_version }}
+    name: Daemonset - k8s ${{ matrix.k8s_version }} ${{ matrix.image_type }}
     runs-on: ubuntu-latest
 
     needs: pre_job
@@ -44,6 +44,9 @@ jobs:
           - 'v1.16.4'
           - 'v1.17.2'
           - 'v1.22.2'
+        image_type:
+          - "buster"
+          - "alpine"
 
     steps:
       - name: Checkout Repository
@@ -68,6 +71,7 @@ jobs:
         with:
           scalyr_api_key: "${{ secrets.SCALYR_WRITE_API_KEY_US }}"
           values_file_path: "ci/daemonset-agent-values.yaml"
+          image_type: "${{ matrix.image_type }}"
 
       - name: Verify Agent Logs are Ingested
         env:
@@ -119,7 +123,7 @@ jobs:
       #     channel: '#cloud-tech'
 
   deployment_controller_type:
-    name: Deployment - k8s ${{ matrix.k8s_version }}
+    name: Deployment - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
 
     needs: pre_job
@@ -133,6 +137,9 @@ jobs:
           - 'v1.16.4'
           - 'v1.17.2'
           - 'v1.22.2'
+        image_type:
+          - "buster"
+          - "alpine"
 
     steps:
       - name: Checkout Repository
@@ -157,6 +164,7 @@ jobs:
         with:
           scalyr_api_key: "${{ secrets.SCALYR_WRITE_API_KEY_US }}"
           values_file_path: "ci/deployment-agent-values.yaml"
+          image_type: "${{ matrix.image_type }}"
 
       - name: Verify Logs are Ingested
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-agent-2/blob/master/CHANGELOG.md.
 
+## 0.2.8
+
+- Update agent to the latest stable version (v2.1.28). This new agent version Docker Images now utilize Python 3.8.
+- Add new ``image.distro`` config option with which user can specify which base distro image to use (``buster``, ``alpine``). Defaults to ``buster``.
+
 ## 0.2.7
 
 - Update agent to the latest stable version (v2.1.25).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
 ## 0.2.8
 
 - Update agent to the latest stable version (v2.1.28). This new agent version Docker Images now utilize Python 3.8.
-- Add new ``image.distro`` config option with which user can specify which base distro image to use (``buster``, ``alpine``). Defaults to ``buster``.
+- Add new ``image.type`` config option with which user can specify which base type image to use (``buster``, ``alpine``). Defaults to ``buster``.
 
 ## 0.2.7
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For chart changelog, please see <https://github.com/scalyr/helm-scalyr/blob/main
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"scalyr/scalyr-k8s-agent"` | Image to use. Defaults to the official scalyr agent image |
 | image.tag | string | `""` | Tag to use. Defaults to appVersion from the chart metadata |
+| image.type | string | `"buster"` | Which image distribution to use - "buster" for Debian Buster and "alpine" for Alpine Linux based image. Alpine Linux images are around 50% smaller in size than Debian buster based ones. |
 | imagePullSecrets | list | `[]` | Image pull secrets to use if the image is in a private repository |
 | livenessProbe.enabled | bool | `true` | set to false to disable default liveness probe which utilizes scalyr-agent-2 status -H command |
 | livenessProbe.timeoutSeconds | int | `10` | timeout in seconds after which probe should be considered as failed if there is no response |

--- a/charts/scalyr-agent/Chart.yaml
+++ b/charts/scalyr-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scalyr-agent
 description: A Helm chart for deploying the Scalyr agent
 type: application
-version: 0.2.7
-appVersion: 2.1.25
+version: 0.2.8
+appVersion: 2.1.26
 keywords:
   - scalyr
   - logging

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -55,7 +55,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- if eq .Values.image.distro 'alpine' }}-alpine{{- end }}"
+          {{- if eq .Values.image.distro "alpine" }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-alpine"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -57,8 +57,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if eq .Values.image.distro "alpine" }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-alpine"
-          {{- else }}
+          {{- else if eq .Values.image.distro "buster"}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          {{- fail "Valid values for .Values.image.distro are: buster, alpine" }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- if eq .Values.image.distro 'alpine' }}-alpine{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -55,12 +55,12 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if eq .Values.image.distro "alpine" }}
+          {{- if eq .Values.image.type "alpine" }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-alpine"
-          {{- else if eq .Values.image.distro "buster"}}
+          {{- else if eq .Values.image.type "buster"}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- else }}
-          {{- fail "Valid values for .Values.image.distro are: buster, alpine" }}
+          {{- fail "Valid values for .Values.image.type are: buster, alpine" }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -56,12 +56,12 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if eq .Values.image.distro "alpine" }}
+          {{- if eq .Values.image.type "alpine" }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-alpine"
-          {{- else if eq .Values.image.distro "buster"}}
+          {{- else if eq .Values.image.type "buster"}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- else }}
-          {{- fail "Valid values for .Values.image.distro are: buster, alpine" }}
+          {{- fail "Valid values for .Values.image.type are: buster, alpine" }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- if eq .Values.image.distro 'alpine' }}-alpine{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -58,8 +58,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if eq .Values.image.distro "alpine" }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-alpine"
-          {{- else }}
+          {{- else if eq .Values.image.distro "buster"}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          {{- fail "Valid values for .Values.image.distro are: buster, alpine" }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -56,7 +56,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- if eq .Values.image.distro 'alpine' }}-alpine{{- end }}"
+          {{- if eq .Values.image.distro "alpine" }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-alpine"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -51,8 +51,8 @@ image:
   pullPolicy: IfNotPresent
   # image.tag -- Tag to use. Defaults to appVersion from the chart metadata
   tag: ""
-  # image.distro - Which distribution to use - "buster" for Debian Buster and "alpine" for Alpine Linux based image. Alpine Linux images are around 50% smaller in size than Debian buster based ones.
-  distro: "buster"
+  # image.type - Which image distribution to use - "buster" for Debian Buster and "alpine" for Alpine Linux based image. Alpine Linux images are around 50% smaller in size than Debian buster based ones.
+  type: "buster"
 
 # imagePullSecrets -- Image pull secrets to use if the image is in a private repository
 imagePullSecrets: []

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -51,7 +51,7 @@ image:
   pullPolicy: IfNotPresent
   # image.tag -- Tag to use. Defaults to appVersion from the chart metadata
   tag: ""
-  # image.type - Which image distribution to use - "buster" for Debian Buster and "alpine" for Alpine Linux based image. Alpine Linux images are around 50% smaller in size than Debian buster based ones.
+  # image.type -- Which image distribution to use - "buster" for Debian Buster and "alpine" for Alpine Linux based image. Alpine Linux images are around 50% smaller in size than Debian buster based ones.
   type: "buster"
 
 # imagePullSecrets -- Image pull secrets to use if the image is in a private repository

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -51,6 +51,8 @@ image:
   pullPolicy: IfNotPresent
   # image.tag -- Tag to use. Defaults to appVersion from the chart metadata
   tag: ""
+  # image.distro - Which distribution to use - "buster" for Debian Buster and "alpine" for Alpine Linux based image. Alpine Linux images are around 50% smaller in size than Debian buster based ones.
+  distro: "buster"
 
 # imagePullSecrets -- Image pull secrets to use if the image is in a private repository
 imagePullSecrets: []

--- a/ci/daemonset-agent-values.yaml
+++ b/ci/daemonset-agent-values.yaml
@@ -6,3 +6,5 @@ scalyr:
   apiKey: "REPLACE_ME"
   k8s:
     verifyKubeletQueries: false
+image:
+  distro: "IMAGE_TYPE"


### PR DESCRIPTION
This pull request updates scalyr agent to v2.1.26.

In addition to that, it adds new ``image.distro`` config option with which user can select to use Alpine Linux based image instead of the default Debian Buster based one.