### PR TITLE
Update e2e tests - drop testing under Kubernetes v1.16 and test under v1.20 instead

### DIFF
--- a/.github/actions/setup-chart-testing-environment/action.yml
+++ b/.github/actions/setup-chart-testing-environment/action.yml
@@ -56,7 +56,10 @@ runs:
         step: |
           shell: bash
           run: |
-            kubectl -n kube-system rollout restart deployment coredns
+            # Workaround for occasional DNS issues
+            # kubectl -n kube-system rollout restart deployment coredns
             kubectl version
             minikube addons list
-            sleep 5
+            kubectl get nodes
+            kubectl cluster-info
+            kubectl get pods -A

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -41,8 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s_version:
-          - 'v1.16.4'
           - 'v1.17.2'
+          - 'v1.20.15'
           - 'v1.22.2'
         image_type:
           - "buster"


### PR DESCRIPTION
This PR updates end to end tests so we test under Kubernetes v1.20 and stop testing under older v1.16 version.