### PR TITLE
Permit ServiceAccount annotation as a value

### DIFF
--- a/charts/scalyr-agent/templates/serviceaccount.yaml
+++ b/charts/scalyr-agent/templates/serviceaccount.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "scalyr-helm.fullname" . }}-sa
   labels:
     {{- include "scalyr-helm.labels" . | nindent 4 }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
 secrets:
   - name: "scalyr-api-key"
 automountServiceAccountToken: true

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -101,3 +101,7 @@ tolerations:
 
 # affinity -- optional affinity rules
 affinity: {}
+
+# Values relevant to ServiceAccount
+serviceAccount:
+  annotations: {}


### PR DESCRIPTION
This change allows one to pass a `.serviceAccount.annotations` value to the chart. This is useful for if for example you are using [IAM Roles for Service Accounts](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html) in order to give the pods an IAM role, in order to retrieve a secret such as the SCALYR_API_KEY on EKS.

Please advise if there are other contribution guidelines to follow EG chart version number update, changelog etc.