### PR TITLE
Add new scalyr.k8s.enableExplorer chart config option which enables Kubernetes Explorer

### DIFF
--- a/.github/actions/setup-chart-testing-environment/action.yml
+++ b/.github/actions/setup-chart-testing-environment/action.yml
@@ -5,7 +5,7 @@ inputs:
   minikube_version:
     description: "Minikube version to use"
     required: false
-    default: "v1.25.1"
+    default: "v1.26.1"
   k8s_version:
     description: "Kubernetes version to be installed by minikube (if any)"
     required: false

--- a/.github/actions/setup-chart-testing-environment/action.yml
+++ b/.github/actions/setup-chart-testing-environment/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         if: ${{ inputs.k8s_version != '' }}
         step: |
-          uses: manusa/actions-setup-minikube@3cce81c968cabc530141d5620b7d9942a2907df5 # v2.4.2
+          uses: manusa/actions-setup-minikube@a36e52547d6fb013f8873758b695ae97a353377b # v2.7.0
           with:
             minikube version: '${{ inputs.minikube_version }}'
             kubernetes version: '${{ inputs.k8s_version }}'

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -40,7 +40,8 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+    #if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ false }}
 
     strategy:
       fail-fast: false
@@ -142,7 +143,8 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+    #if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ false }}
 
     strategy:
       fail-fast: false
@@ -196,6 +198,80 @@ jobs:
 
           # Verify Kubernetes metrics are beeing ingested
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-deployment=\"scalyr-agent\""'
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/main' || github.head_ref == 'main') }}
+        uses: act10ns/slack@e4e71685b9b239384b0f676a63c32367f59c2522 # v1.2.2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'
+
+  daemonset_controller_type_k8s_explorer:
+    name: Daemonset (Explorer) - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
+    runs-on: ubuntu-latest
+
+    needs: pre_job
+    # NOTE: We always want to run job on main branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version:
+          - 'v1.22.2'
+        image_type:
+          - "buster"
+          - "alpine"
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Chart Testing Environment and Kubernetes Cluster
+        uses: ./.github/actions/setup-chart-testing-environment/
+        with:
+          k8s_version: "${{ matrix.k8s_version }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Scalyr tool
+        run: |
+          curl https://raw.githubusercontent.com/scalyr/scalyr-tool/master/scalyr > scalyr
+          chmod +x scalyr
+          sudo mv scalyr /usr/local/bin
+
+      - name: Install Helm Chart
+        uses: ./.github/actions/install-helm-chart
+        with:
+          scalyr_api_key: "${{ secrets.SCALYR_WRITE_API_KEY_US }}"
+          values_file_path: "ci/daemonset-agent-values-with-k8s-explorer.yaml"
+          image_type: "${{ matrix.image_type }}"
+
+      - name: Verify Agent Logs are Ingested
+        env:
+          scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"
+          SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
+        run: |
+          # Verify agent and kubernetes monitor has been started
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "No checkpoints were found. All logs will be copied starting at their current end"'
+
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Cluster name detected, enabling k8s metric reporting"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "kubernetes_monitor parameters: "'
+
+          # Verify Kubernetes metrics are beeing ingested
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-daemon-set=\"scalyr-agent\""'
+
+          # Verify Kubernetes Explorer logs are there - note: logs won't be complete since atm we
+          # don't install kube state + node exporter metrics exporter
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" logfile contains "openmetrics_monitor" "k8s-daemon-set=\"scalyr-agent\""'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -225,6 +225,7 @@ jobs:
       matrix:
         k8s_version:
           - 'v1.22.2'
+          - 'v1.24.3'
         image_type:
           - "buster"
           - "alpine"

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -225,7 +225,7 @@ jobs:
       matrix:
         k8s_version:
           - 'v1.22.2'
-          - 'v1.24.3'
+          - 'v1.24.2'
         image_type:
           - "buster"
           - "alpine"

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -301,6 +301,16 @@ jobs:
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting monitor openmetrics_monitor"'
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent_debug.log" "Adding new monitor with config:"'
 
+          # Assert that Kubernetes Explorer metrics which we scrape from 2 annotated pods are there
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" logfile contains "node-exporter" k8s-cluster="k8s-explorer-e2e-tests" k8s-daemon-set="node-exporter" "level=info collector=cpu"'
+
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" monitor="openmetrics_monitor" logfile contains "kubernetes-api-cadvisor-metrics.log" k8s-cluster="k8s-explorer-e2e-tests"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" monitor="openmetrics_monitor" logfile contains "kubernetes-api-cadvisor-metrics.log" k8s-cluster="k8s-explorer-e2e-tests" "container_start_time_seconds "'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" monitor="openmetrics_monitor" logfile contains "kubernetes-api-cadvisor-metrics.log" k8s-cluster="k8s-explorer-e2e-tests" "container_spec_memory_limit_bytes "'
+
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" monitor="openmetrics_monitor" logfile contains "node-exporter" k8s-cluster="k8s-explorer-e2e-tests"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" monitor="openmetrics_monitor" logfile contains "node-exporter" k8s-cluster="k8s-explorer-e2e-tests" "process_resident_memory_bytes"'
+
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
         # requests and that's why we need this special conditional and check for github.head_ref in

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -40,16 +40,15 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on main branch
-    #if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
-    if: ${{ false }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
       matrix:
         k8s_version:
-          - 'v1.17.2'
           - 'v1.20.15'
           - 'v1.22.2'
+          - 'v1.24.3'
         image_type:
           - "buster"
           - "alpine"
@@ -143,16 +142,15 @@ jobs:
 
     needs: pre_job
     # NOTE: We always want to run job on main branch
-    #if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
-    if: ${{ false }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
       matrix:
         k8s_version:
-          - 'v1.16.4'
           - 'v1.17.2'
           - 'v1.22.2'
+          - 'v1.24.3'
         image_type:
           - "buster"
           - "alpine"

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -225,7 +225,7 @@ jobs:
       matrix:
         k8s_version:
           - 'v1.22.2'
-          - 'v1.24.2'
+          - 'v1.24.3'
         image_type:
           - "buster"
           - "alpine"

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -255,6 +255,28 @@ jobs:
           values_file_path: "ci/daemonset-agent-values-with-k8s-explorer.yaml"
           image_type: "${{ matrix.image_type }}"
 
+      # Create mock pods and exporters which will be scrapped by the monitor
+      # (step taken from scalyr-agent-2 repo)
+      - name: Create mock pods and exporters
+        run: |
+          git clone --depth 1 https://github.com/scalyr/scalyr-agent-2.git
+
+          kubectl create namespace monitoring
+
+          # 1. node exporter pod
+          pushd scalyr-agent-2/
+          kubectl apply -f tests/e2e/k8s_om_monitor/node_exporter.yaml
+
+          # 2. kube state metrics deployment
+          kubectl apply -k tests/e2e/k8s_om_monitor/kube-state-metrics/
+
+          # 3. Install dummy java app container with jmx exporter side
+          kubectl apply -f tests/e2e/k8s_om_monitor/java_app_deployment.yaml
+          popd
+
+          sleep 20
+          kubectl get pods -A
+
       - name: Verify Agent Logs are Ingested
         env:
           scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -266,12 +266,17 @@ jobs:
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Cluster name detected, enabling k8s metric reporting"'
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "kubernetes_monitor parameters: "'
 
+          #./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Config option '\'stop_agent_on_failure\'' is enabled"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "stop_agent_on_failure"'
+
           # Verify Kubernetes metrics are beeing ingested
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-daemon-set=\"scalyr-agent\""'
 
           # Verify Kubernetes Explorer logs are there - note: logs won't be complete since atm we
           # don't install kube state + node exporter metrics exporter
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" logfile contains "openmetrics_monitor" "k8s-daemon-set=\"scalyr-agent\""'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "monitor:openmetrics_monitor"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting monitor openmetrics_monitor"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent_debug.log" "Adding new monitor with config:"'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
 
   For more information on this functionality, please refer to the docs - https://app.scalyr.com/help/scalyr-agent-k8s-explorer.
 
+- Make sure ``kubernetes_monitor`` has ``stop_agent_on_failure`` monitor config option set to
+  ``true`` (which is the default upstream value).
+
+- Add new ``scalyr.debugLevel`` and ``scalyr.ingestDebugLog`` chart config option which enables
+  debug logging + debug log ingestion which can help with troubleshooting.
+
 ## 0.2.16
 
 - Update agent to the latest stable version (v2.1.33).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-agent-2/blob/release/CHANGELOG.md
 
+## 0.2.17
+
+- Add new ``scalyr.k8s.enableExplorer`` chart config option. When this option is set to true, it
+  enabled Kubernetes Explorer (https://www.dataset.com/blog/introducing-dataset-kubernetes-explorer/)
+  functionality.
+
+  For more information on this functionality, please refer to the docs - https://app.scalyr.com/help/scalyr-agent-k8s-explorer.
+
 ## 0.2.16
 
 - Update agent to the latest stable version (v2.1.33).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
 - Add new ``scalyr.debugLevel`` and ``scalyr.ingestDebugLog`` chart config option which enables
   debug logging + debug log ingestion which can help with troubleshooting.
 
+- Update default ``ClusterRole`` definition so it also grants get permissions to ``nodes/proxy``
+  and ``/metrics`` endpoints which are required for the Kubernetes Explorer functionality.
+
 ## 0.2.16
 
 - Update agent to the latest stable version (v2.1.33).

--- a/README.md
+++ b/README.md
@@ -112,16 +112,19 @@ For chart changelog, please see <https://github.com/scalyr/helm-scalyr/blob/main
 | scalyr.apiKey | string | `""` | The Scalyr API key to use |
 | scalyr.base64Config | bool | `true` | As Helm is currently [unable to correctly pass JSON strings](https://github.com/helm/helm/issues/5618), this can be set to true so all values of scalyr.config are expected to be base64 encoded and will be decoded in the chart |
 | scalyr.config | object | `{}` | A hash of configuration files and their content as documented in the [Scalyr agent configmap configuration documentation](https://app.scalyr.com/help/scalyr-agent-k8s#modify-config) |
+| scalyr.debugLevel | int | `0` | Set this to number between 1 and 5 (inclusive to enable additional debug logging into agent_debug.log). NOTE: If you want this debug log file to be ingested into Scalyr, you should also set scalyr.ingestDebugLog option to true. |
+| scalyr.ingestDebugLog | bool | `false` |  |
 | scalyr.k8s.caCert | string | `""` | The path to the CA certificate to use to verify TLS-connection to the kubelet |
 | scalyr.k8s.clusterName | string | `""` | The kubernetes cluster name (when using the kubernetes monitoring) |
 | scalyr.k8s.enableEvents | bool | `true` | Enable fetching Kubernetes events |
+| scalyr.k8s.enableExplorer | bool | `false` | Enable Kubernetes Explorer functionality (https://www.dataset.com/blog/introducing-dataset-kubernetes-explorer/). This functionality may require additional setup, for more information, please refer to the docs - https://app.scalyr.com/help/scalyr-agent-k8s-explorer NOTE: Explorer functionality is only supported when using DaemonSet agent deployment model. |
 | scalyr.k8s.enableLogs | bool | `true` | Enable fetching Pod/Container logs from Kubernetes |
 | scalyr.k8s.enableMetrics | bool | `true` | Enable fetching Kubernetes metrics. This requires scalyr.k8s.enableLogs to be true |
 | scalyr.k8s.verifyKubeletQueries | bool | `true` | Set this to false to disable TLS cert validation of queries to k8s kubelet. By default cert validation is enabled and connection is verified using the CA configured via the service account certificate (/run/secrets/kubernetes.io/serviceaccount/ca.crt file). If you want to use a custom CA bundle, you can do that by setting scalyr.k8s.caCert config option to point to this file (this file needs to be available inside the agent container). In some test environments such as minikube where self signed certs are used you may want to set this to false. |
 | scalyr.server | string | `"agent.scalyr.com"` | The Scalyr server to send logs to. Use eu.scalyr.com for EU |
 | securityContext | object | `{}` | optional security context entries |
-| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Pod tolerations. Defaults to the values documented in the official [Installation guide](https://app.scalyr.com/help/install-agent-kubernetes) |
 | serviceAccount.annotations | object | `{}` | optional arbitrary service account annotations |
+| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Pod tolerations. Defaults to the values documented in the official [Installation guide](https://app.scalyr.com/help/install-agent-kubernetes) |
 | volumeMounts | object | `{}` | Additional volume mounts to set up |
 | volumes | object | `{}` | Additional volumes to mount |
 

--- a/charts/scalyr-agent/Chart.yaml
+++ b/charts/scalyr-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalyr-agent
 description: A Helm chart for deploying the Scalyr agent
 type: application
-version: 0.2.16
+version: 0.2.17
 appVersion: 2.1.33
 keywords:
   - scalyr

--- a/charts/scalyr-agent/templates/cluster-role.yaml
+++ b/charts/scalyr-agent/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
+{{- if (or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) .Values.scalyr.k8s.enableExplorer) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -51,10 +51,17 @@ rules:
       - "get"
       - "list"
       - "watch"
+  # nodes/proxy and /metrics permissions are needed for Kubernetes Open Metrics monitor
+  # so local Kubelet API can be queried for metrics in Open Metrics format.
   - apiGroups:
       - ""
     resources:
       - "nodes/stats"
+      - "nodes/proxy"
+    verbs:
+      - "get"
+  - nonResourceURLs:
+      - "/metrics"
     verbs:
       - "get"
 {{- end }}

--- a/charts/scalyr-agent/templates/configmap.yaml
+++ b/charts/scalyr-agent/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
           "report_container_metrics": {{ .Values.scalyr.k8s.enableMetrics }},
           "report_k8s_metrics": {{ .Values.scalyr.k8s.enableMetrics }}
         },
+        {{- end }}
         {{- if .Values.scalyr.k8s.enableExplorer }}
         {
           module:  "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
@@ -56,7 +57,10 @@ data:
       "logs": [
         {
            "path": "/var/log/scalyr-agent-2/agent_debug.log",
-           attributes: { parser: "accessLog" },
+           "attributes":
+             {
+               "parser": "scalyrAgentLog"
+             },
         },
       ]
     }

--- a/charts/scalyr-agent/templates/configmap.yaml
+++ b/charts/scalyr-agent/templates/configmap.yaml
@@ -19,6 +19,21 @@ data:
           "module": "scalyr_agent.builtin_monitors.kubernetes_monitor",
           "report_container_metrics": {{ .Values.scalyr.k8s.enableMetrics }},
           "report_k8s_metrics": {{ .Values.scalyr.k8s.enableMetrics }}
+        },
+        {{- if .Values.scalyr.k8s.enableExplorer }}
+        {
+          module:  "scalyr_agent.builtin_monitors.kubernetes_openmetrics_monitor",
+          include_node_name: true,
+          include_cluster_name: true,
+          logger_include_node_name: false,
+          // Switch to true once preview phase is over
+          verify_https: false,
+          scrape_kubernetes_api_metrics: false,
+          kubernetes_api_metrics_scrape_interval: 60,
+          scrape_kubernetes_api_cadvisor_metrics: true,
+          kubernetes_api_cadvisor_metrics_scrape_interval: 60,
+          sample_interval: 60,
+          scrape_interval: 60
         }
         {{- end }}
       ]

--- a/charts/scalyr-agent/templates/configmap.yaml
+++ b/charts/scalyr-agent/templates/configmap.yaml
@@ -34,3 +34,14 @@ data:
     {{- end }}
     {{ if $.Values.scalyr.base64Config }}{{ $value | b64dec }}{{ else }}{{ $value }}{{ end }}
   {{- end }}
+  {{- if .Values.scalyr.ingestDebugLog }}
+  "debug_log.json": |
+    {
+      "logs": [
+        {
+           "path": "/var/log/scalyr-agent-2/agent_debug.log",
+           attributes: { parser: "accessLog" },
+        },
+      ]
+    }
+  {{- end }}

--- a/charts/scalyr-agent/templates/configmap.yaml
+++ b/charts/scalyr-agent/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
         {{- if .Values.scalyr.k8s.enableLogs }}
         {
           "module": "scalyr_agent.builtin_monitors.kubernetes_monitor",
+          "stop_agent_on_failure": true,
           "report_container_metrics": {{ .Values.scalyr.k8s.enableMetrics }},
           "report_k8s_metrics": {{ .Values.scalyr.k8s.enableMetrics }}
         },

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -91,6 +91,10 @@ spec:
             - name: "SCALYR_K8S_KUBELET_CA_CERT"
               value: "{{ .Values.scalyr.k8s.caCert }}"
             {{- end }}
+            {{- if (.Values.scalyr.k8s.enableExplorer) }}
+            - name: "SCALYR_K8S_EXPLORER_ENABLE"
+              value: "true"
+            {{- end }}
             - name: "SCALYR_K8S_NODE_NAME"
               valueFrom:
                 fieldRef:

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -95,6 +95,10 @@ spec:
             - name: "SCALYR_K8S_EXPLORER_ENABLE"
               value: "true"
             {{- end }}
+            {{- if (not (eq (int .Values.scalyr.debugLevel) 0)) }}
+            - name: "SCALYR_DEBUG_LEVEL"
+              value: "{{ .Values.scalyr.debugLevel }}"
+            {{- end }}
             - name: "SCALYR_K8S_NODE_NAME"
               valueFrom:
                 fieldRef:

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
             - name: "SCALYR_K8S_KUBELET_CA_CERT"
               value: "{{ .Values.scalyr.k8s.caCert }}"
             {{- end }}
+            {{- if (not (eq (int .Values.scalyr.debugLevel) 0)) }}
+            - name: "SCALYR_DEBUG_LEVEL"
+              value: "{{ .Values.scalyr.debugLevel }}"
+            {{- end }}
             - name: "SCALYR_K8S_NODE_NAME"
               valueFrom:
                 fieldRef:

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -37,6 +37,11 @@ scalyr:
     enableMetrics: true
     # scalyr.k8s.enableEvents -- Enable fetching Kubernetes events
     enableEvents: true
+    # scalyr.k8s.enableExplorer -- Enable Kubernetes Explorer functionality (https://www.dataset.com/blog/introducing-dataset-kubernetes-explorer/).
+    # This functionality may require additional setup, for more information, please refer to the
+    # docs - https://app.scalyr.com/help/scalyr-agent-k8s-explorer
+    # NOTE: Explorer functionality is only supported when using DaemonSet agent deployment model.
+    enableExplorer: false
   # scalyr.config -- A hash of configuration files and their content as documented in the
   # [Scalyr agent configmap configuration documentation](https://app.scalyr.com/help/scalyr-agent-k8s#modify-config)
   config: {}

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -19,6 +19,12 @@ scalyr:
   server: "agent.scalyr.com"
   # scalyr.apiKey -- The Scalyr API key to use
   apiKey: ""
+  # scalyr.debugLevel -- Set this to number between 1 and 5 (inclusive to enable additional debug
+  # logging into agent_debug.log).
+  # NOTE: If you want this debug log file to be ingested into Scalyr, you should also set
+  # scalyr.ingestDebugLog option to true.
+  debugLevel: 0
+  ingestDebugLog: false
   k8s:
     # scalyr.k8s.clusterName -- The kubernetes cluster name (when using the kubernetes monitoring)
     clusterName: ""

--- a/ci/daemonset-agent-values-with-k8s-explorer.yaml
+++ b/ci/daemonset-agent-values-with-k8s-explorer.yaml
@@ -1,0 +1,12 @@
+# Values file used by end to end tests
+controllerType: "daemonset"
+podLabels:
+  test: "true"
+scalyr:
+  clusterName: "k8s-explorer-e2e-tests"
+  apiKey: "REPLACE_ME"
+  k8s:
+    verifyKubeletQueries: false
+    enableExplorer: true
+image:
+  distro: "IMAGE_TYPE"

--- a/ci/daemonset-agent-values-with-k8s-explorer.yaml
+++ b/ci/daemonset-agent-values-with-k8s-explorer.yaml
@@ -5,6 +5,8 @@ podLabels:
 scalyr:
   clusterName: "k8s-explorer-e2e-tests"
   apiKey: "REPLACE_ME"
+  debugLevel: 1
+  ingestDebugLog: true
   k8s:
     verifyKubeletQueries: false
     enableExplorer: true

--- a/ci/daemonset-agent-values-with-k8s-explorer.yaml
+++ b/ci/daemonset-agent-values-with-k8s-explorer.yaml
@@ -3,11 +3,11 @@ controllerType: "daemonset"
 podLabels:
   test: "true"
 scalyr:
-  clusterName: "k8s-explorer-e2e-tests"
   apiKey: "REPLACE_ME"
   debugLevel: 1
   ingestDebugLog: true
   k8s:
+    clusterName: "k8s-explorer-e2e-tests"
     verifyKubeletQueries: false
     enableExplorer: true
 image:

--- a/updateDoc.sh
+++ b/updateDoc.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
+docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest --dry-run


### PR DESCRIPTION
This pull request adds new ``scalyr.k8s.enableExplorer`` chart config option. When this config option is enabled / set to true, Kubernetes Explorer functionality is enabled in the agent.


NOTE: At this point to get a complete Kubernetes Explorer experience, user still needs to install and configure kubernetes state metrics exporter and node exporter pods to be scraped as per docs (https://app.scalyr.com/help/scalyr-agent-k8s-explorer).