### PR TITLE
Added option to use existing secretRef for api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
 
 ## 0.2.21
 
-- Add new ``existingSecretRef`` chart value. When set (defaults to "" / unset), it will use that
+- Add new ``existingSecretRef`` chart value. When set (defaults to unset), it will use that
   value for the agent ``secretKeyRef`` ``name`` field value. When not set, ``secretKeyRef``
-  ``name`` field value defaults to `` "{{ include "scalyr-helm.fullname" . }}-scalyr-api-key"``.
+  ``name`` field value defaults to ``{{ include "scalyr-helm.fullname" . }}-scalyr-api-key``.
 
 ## 0.2.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-agent-2/blob/release/CHANGELOG.md
 
+## 0.2.21
+
+- Add new ``existingSecretRef`` chart value. When set (defaults to "" / unset), it will use that
+  value for the agent ``secretKeyRef`` ``name`` field value. When not set, ``secretKeyRef``
+  ``name`` field value defaults to `` "{{ include "scalyr-helm.fullname" . }}-scalyr-api-key"``.
+
 ## 0.2.20
 
 - Update agent to the latest stable version (v2.1.36).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
   value for the agent ``secretKeyRef`` ``name`` field value. When not set, ``secretKeyRef``
   ``name`` field value defaults to ``{{ include "scalyr-helm.fullname" . }}-scalyr-api-key``.
 
+  This allows users to re-use the existing Kubernetes secret where DataSet API key is stored.
+
 ## 0.2.20
 
 - Update agent to the latest stable version (v2.1.36).

--- a/charts/scalyr-agent/Chart.yaml
+++ b/charts/scalyr-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalyr-agent
 description: A Helm chart for deploying the Scalyr agent
 type: application
-version: 0.2.19
+version: 0.2.20
 appVersion: 2.1.33
 keywords:
   - scalyr

--- a/charts/scalyr-agent/Chart.yaml
+++ b/charts/scalyr-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalyr-agent
 description: A Helm chart for deploying the Scalyr agent
 type: application
-version: 0.2.20
+version: 0.2.21
 appVersion: 2.1.36
 keywords:
   - scalyr

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -85,7 +85,11 @@ spec:
             - name: "SCALYR_API_KEY"
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.existingSecretRef }}
+                  name: {{ .Values.existingSecretRef }}
+                  {{- else }}
                   name: "{{ include "scalyr-helm.fullname" . }}-scalyr-api-key"
+                  {{- end }}
                   key: "scalyr-api-key"
             {{- if (or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) (.Values.scalyr.k8s.enableExplorer))  }}
             - name: "SCALYR_K8S_CLUSTER_NAME"

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -86,7 +86,11 @@ spec:
             - name: "SCALYR_API_KEY"
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.existingSecretRef }}
+                  name: {{ .Values.existingSecretRef }}
+                  {{- else }}
                   name: "{{ include "scalyr-helm.fullname" . }}-scalyr-api-key"
+                  {{- end }}
                   key: "scalyr-api-key"
             {{- if (or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) (.Values.scalyr.k8s.enableExplorer))  }}
             - name: "SCALYR_K8S_CLUSTER_NAME"

--- a/charts/scalyr-agent/templates/secret.yaml
+++ b/charts/scalyr-agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.existingSecretRef "" -}}
 {{- $name := .Values.scalyr.apiKey | required ".Values.scalyr.apiKey is required." -}}
 
 apiVersion: v1
@@ -8,3 +9,4 @@ metadata:
   {{- include "scalyr-helm.labels" . | nindent 4 }}
 data:
   scalyr-api-key: {{ .Values.scalyr.apiKey | b64enc }}
+{{- end }}

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -133,3 +133,6 @@ affinity: {}
 serviceAccount:
   # serviceAccount.annotations -- optional arbitrary service account annotations
   annotations: {}
+
+# Use this value if the Scalyr API key is already stored in a Kubernetes secret that was created by an external secrets operator or similar.
+existingSecretRef: ""


### PR DESCRIPTION
We are using external secrets operator, which creates secrets objects from AWS secrets manager. please consider adding this option.