### PR TITLE
Fix `.Values.volumeMounts` not being used in daemonset and deployment templates

### DIFF
--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -144,8 +144,8 @@ spec:
             - name: "dockersock"
               mountPath: "/var/scalyr/docker.sock"
           {{- end }}
-          {{- if .Values.volumes }}
-          {{ toYaml .Values.volumes | nindent 12 }}
+          {{- if .Values.volumeMounts }}
+          {{ toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}
             - name: "checkpoints"
               mountPath: "/var/lib/scalyr-agent-2"

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -141,8 +141,8 @@ spec:
             - name: "dockersock"
               mountPath: "/var/scalyr/docker.sock"
           {{- end }}
-          {{- if .Values.volumes }}
-          {{ toYaml .Values.volumes | nindent 12 }}
+          {{- if .Values.volumeMounts }}
+          {{ toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}
             - name: "checkpoints"
               mountPath: "/var/lib/scalyr-agent-2"


### PR DESCRIPTION
Fix for #25