### PR TITLE
Exercise additional chart config options (values) / code paths as part of end to end tests

### DIFF
--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -76,6 +76,10 @@ jobs:
           values_file_path: "ci/daemonset-agent-values.yaml"
           image_type: "${{ matrix.image_type }}"
 
+      - name: Describe Pod
+        run: |
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME}
+
       - name: Verify Agent Logs are Ingested
         env:
           scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"
@@ -174,13 +178,15 @@ jobs:
           values_file_path: "ci/deployment-agent-values.yaml"
           image_type: "${{ matrix.image_type }}"
 
+      - name: Describe Pod
+        run: |
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME}
+
       - name: Verify Logs are Ingested
         env:
           scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
         run: |
-          export POD_NAME=$(kubectl get pod --selector=test=true -o jsonpath="{.items[0].metadata.name}")
-
           # Verify agent and kubernetes monitor has been started
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Starting scalyr agent..."'
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "No checkpoints were found. All logs will be copied starting at their current end"'

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -82,11 +82,11 @@ jobs:
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
         run: |
           # Verify agent and kubernetes monitor has been started
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "No checkpoints were found. All logs will be copied starting at their current end"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Starting scalyr agent..."'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "No checkpoints were found. All logs will be copied starting at their current end"'
 
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Cluster name detected, enabling k8s metric reporting"'
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "kubernetes_monitor parameters: "'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Cluster name detected, enabling k8s metric reporting"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "kubernetes_monitor parameters: "'
 
           # Verify Kubernetes metrics are beeing ingested
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-daemon-set=\"scalyr-agent\""'
@@ -182,11 +182,11 @@ jobs:
           export POD_NAME=$(kubectl get pod --selector=test=true -o jsonpath="{.items[0].metadata.name}")
 
           # Verify agent and kubernetes monitor has been started
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Starting scalyr agent..."'
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "No checkpoints were found. All logs will be copied starting at their current end"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Starting scalyr agent..."'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "No checkpoints were found. All logs will be copied starting at their current end"'
 
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "Cluster name detected, enabling k8s metric reporting"'
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" "kubernetes_monitor parameters: "'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Cluster name detected, enabling k8s metric reporting"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "kubernetes_monitor parameters: "'
 
           # Verify Kubernetes metrics are beeing ingested
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-deployment=\"scalyr-agent\""'

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -78,7 +78,13 @@ jobs:
 
       - name: Describe Pod
         run: |
+          set -e
+
           kubectl describe pod ${SCALYR_AGENT_POD_NAME}
+
+          # Verify test volume defined using chart volumes and volumeMounts value is there
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "/test-volume from test-volume (rw)"
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "test-volume:"
 
       - name: Verify Agent Logs are Ingested
         env:
@@ -180,7 +186,13 @@ jobs:
 
       - name: Describe Pod
         run: |
+          set -e
+
           kubectl describe pod ${SCALYR_AGENT_POD_NAME}
+
+          # Verify test volume defined using chart volumes and volumeMounts value is there
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "/test-volume from test-volume (rw)"
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "test-volume:"
 
       - name: Verify Logs are Ingested
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-agent-2/blob/release/CHANGELOG.md
 
+## 0.2.24
+
+- Small template formatting fix for DaemonSet and Deployment template ``volumes`` and
+  ``volumeMounts`` section. #35
+
 ## 0.2.23
 
 - Fix a bug with ``scalyr.base64Config`` chart value not being correctly indented in the ConfigMap

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ For example, let's say your custom config fragment lives in ``ci/examples/agent.
 1. Obtain base64 encoded version of the JSON file content
 
 ```bash
-cat ci/examples/agent.d/my-config.json | sed -e 's/^ *//' | tr -d '\n' | base64
+cat ci/examples/agent.d/my-config.json | sed -e 's/^ *//' | tr -d '\n' | base64 | tr -d '\n' ; echo ""
 ```
 
 To avoid any YAML formatting issues, we also utilize ``sed`` and ``tr`` command to fold multi line

--- a/charts/scalyr-agent/Chart.yaml
+++ b/charts/scalyr-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalyr-agent
 description: A Helm chart for deploying the Scalyr agent
 type: application
-version: 0.2.23
+version: 0.2.24
 appVersion: 2.1.36
 keywords:
   - scalyr

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             name: "{{ include "scalyr-helm.fullname" . }}-config-agent-d"
             defaultMode: 0600
       {{- if .Values.volumes }}
-      {{ toYaml .Values.volumes | nindent 8 }}
+      {{- toYaml .Values.volumes | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -149,7 +149,7 @@ spec:
               mountPath: "/var/scalyr/docker.sock"
           {{- end }}
           {{- if .Values.volumeMounts }}
-          {{ toYaml .Values.volumeMounts | nindent 12 }}
+          {{- toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}
             - name: "checkpoints"
               mountPath: "/var/lib/scalyr-agent-2"

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             name: "{{ include "scalyr-helm.fullname" . }}-config-agent-d"
             defaultMode: 0600
       {{- if .Values.volumes }}
-      {{ toYaml .Values.volumes | nindent 8 }}
+      {{- toYaml .Values.volumes | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -146,7 +146,7 @@ spec:
               mountPath: "/var/scalyr/docker.sock"
           {{- end }}
           {{- if .Values.volumeMounts }}
-          {{ toYaml .Values.volumeMounts | nindent 12 }}
+          {{- toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}
             - name: "checkpoints"
               mountPath: "/var/lib/scalyr-agent-2"

--- a/ci/daemonset-agent-values.yaml
+++ b/ci/daemonset-agent-values.yaml
@@ -11,5 +11,13 @@ scalyr:
   config:
     test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
 
+volumes:
+  - name: test-volume
+    emptyDir: {}
+
+volumeMounts:
+  - mountPath: /test-volume
+      name: test-volume
+
 image:
   distro: "IMAGE_TYPE"

--- a/ci/daemonset-agent-values.yaml
+++ b/ci/daemonset-agent-values.yaml
@@ -17,7 +17,7 @@ volumes:
 
 volumeMounts:
   - mountPath: /test-volume
-      name: test-volume
+    name: test-volume
 
 image:
   distro: "IMAGE_TYPE"

--- a/ci/daemonset-agent-values.yaml
+++ b/ci/daemonset-agent-values.yaml
@@ -7,5 +7,9 @@ scalyr:
   k8s:
     clusterName: "k8s-explorer-e2e-tests"
     verifyKubeletQueries: false
+  base64Config: true
+  config:
+    test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
+
 image:
   distro: "IMAGE_TYPE"

--- a/ci/daemonset-agent-values.yaml
+++ b/ci/daemonset-agent-values.yaml
@@ -9,6 +9,7 @@ scalyr:
     verifyKubeletQueries: false
   base64Config: true
   config:
+    # ci/examples/agent.d/test-config.json
     test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
 
 volumes:

--- a/ci/deployment-agent-values.yaml
+++ b/ci/deployment-agent-values.yaml
@@ -7,3 +7,7 @@ scalyr:
   k8s:
     clusterName: "k8s-explorer-e2e-tests"
     verifyKubeletQueries: false
+  base64Config: true
+  config:
+    # ci/examples/agent.d/test-config.json
+    test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9

--- a/ci/deployment-agent-values.yaml
+++ b/ci/deployment-agent-values.yaml
@@ -11,3 +11,11 @@ scalyr:
   config:
     # ci/examples/agent.d/test-config.json
     test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
+
+volumes:
+  - name: test-volume
+    emptyDir: {}
+
+volumeMounts:
+  - mountPath: /test-volume
+    name: test-volume

--- a/ci/examples/agent.d/test-config.json
+++ b/ci/examples/agent.d/test-config.json
@@ -1,0 +1,6 @@
+{
+  server_attributes: {
+    attribute1: "value1",
+    attribute2: "value2",
+  },
+}


### PR DESCRIPTION
This pull request updates end to end tests DaemonSet config to also exercise some additional chart values / code paths:

* ``volumes``, ``volumesMount`` chart value
* ``scalyr.config`` chart value

Other changes:

* Small fix in readme in the example base64 bash command
* Small fix in the templates (make sure leading line break is removed before ``volumes`` and ``volumesMount`` section)