### PR TITLE
Add `extraEnvVars` option to `values.yaml` file for better customization

### DIFF
--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -134,6 +134,9 @@ spec:
                   fieldPath: "status.hostIP"
                   apiVersion: "v1"
             {{- end }}
+            {{- if .Values.extraEnvVars }}
+              {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- end }}
           volumeMounts:
           {{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
             - name: "varlibdockercontainers"

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
                   fieldPath: "status.hostIP"
                   apiVersion: "v1"
             {{- end }}
+            {{- if .Values.extraEnvVars }}
+              {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- end }}
           volumeMounts:
           {{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
             - name: "varlibdockercontainers"

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -8,6 +8,15 @@ deployment:
   # deployment.replicaCount -- The count of replicas to use when using the deployment controller setup
   replicaCount: 1
 
+# env -- Additional environment variables to set
+extraEnvVars:
+# extraEnvVars:
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
+
 # volumes -- Additional volumes to mount
 volumes: {}
 


### PR DESCRIPTION
This PR adds `extraEnvVars` customization option in `values.yaml` file for Scalyr agent. However, there is still room for improvements in customizing agent. For example, there is no way to use user created configmap.