### PR TITLE
Adding priorityClassName to scalyr-agent daemonset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ For agent changelog, please see <https://github.com/scalyr/scalyr-agent-2/blob/r
 | podAnnotations | object | `{}` | optional pod annotations |
 | podLabels | object | `{}` | optional arbitrary pod metadata labels |
 | podSecurityContext | object | `{}` | optional pod security context entries |
+| priorityClassName | string | `""` | optional pod priority class name to use for the scalyr-agent daemonset |
 | resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}` | Pod resources. Defaults to the values documented in the official [Installation guide](https://app.scalyr.com/help/install-agent-kubernetes) |
 | scalyr.apiKey | string | `""` | The Scalyr API key to use |
 | scalyr.base64Config | bool | `true` | As Helm is currently [unable to correctly pass JSON strings](https://github.com/helm/helm/issues/5618), this can be set to true so all values of scalyr.config are expected to be base64 encoded and will be decoded in the chart |

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.scalyr.priorityClassName }}
+      priorityClassName: {{ .Values.scalyr.priorityClassName }}
+      {{- end }}
       volumes:
       {{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
         - name: "varlibdockercontainers"

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -35,6 +35,8 @@ scalyr:
   # NOTE: If you want this debug log file to be ingested into Scalyr, you also need to set
   # scalyr.ingestDebugLog option to true.
   debugLevel: 0
+  # Pod priority class name to use for the scalyr-agent daemonset. Optional.
+  priorityClassName: ""
   # scalyr.ingestDebugLog -- Set this to true to enable ingesting of agent_debug.log file. Keep in
   # mind that depending on the debug log level set, this may result in large log volume.
   ingestDebugLog: false


### PR DESCRIPTION
scalyr-agent gets a PriorityClass of default. When there's a cluster upgrade, there's a chance that the agent might not get scheduled on a Node because of all the resources already accounted for. Then the Pod is left in a pending state and you won't see any logs from Pods on that Node. Then manual intervention is needed. If scalyr-agent can be given a higher priority, it can be scheduled first and one will hopefully not run into this issue.

https://github.com/scalyr/helm-scalyr/issues/41