### PR TITLE
Custom service account support

### DIFF
--- a/charts/scalyr-agent/templates/_helpers.tpl
+++ b/charts/scalyr-agent/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+User-overrideable name for the serviceAccount
+*/}}
+{{- define "scalyr-helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.nameOverride }}
+{{- .Values.serviceAccount.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- include "scalyr-helm.fullname" . }}-sa
+{{- end}}
+{{- end}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "scalyr-helm.chart" -}}

--- a/charts/scalyr-agent/templates/cluster-role-binding.yaml
+++ b/charts/scalyr-agent/templates/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
+{{- if and (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) (.Values.serviceAccount.create) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/scalyr-agent/templates/cluster-role-binding.yaml
+++ b/charts/scalyr-agent/templates/cluster-role-binding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: "{{ include "scalyr-helm.fullname" . }}-cluster-role"
 subjects:
   - kind: "ServiceAccount"
-    name: "{{ include "scalyr-helm.fullname" . }}-sa"
+    name: "{{ include "scalyr-helm.serviceAccountName" . }}"
     namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/charts/scalyr-agent/templates/cluster-role.yaml
+++ b/charts/scalyr-agent/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if (or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) .Values.scalyr.k8s.enableExplorer) }}
+{{- if and ((or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) .Values.scalyr.k8s.enableExplorer)) (.Values.serviceAccount.create) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -170,7 +170,7 @@ spec:
       dnsPolicy: "ClusterFirst"
       {{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
       automountServiceAccountToken: true
-      serviceAccountName: "{{ include "scalyr-helm.fullname" . }}-sa"
+      serviceAccountName: "{{ include "scalyr-helm.serviceAccountName" . }}"
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -164,7 +164,7 @@ spec:
       dnsPolicy: "ClusterFirst"
       {{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
       automountServiceAccountToken: true
-      serviceAccountName: "{{ include "scalyr-helm.fullname" . }}-sa"
+      serviceAccountName: "{{ include "scalyr-helm.serviceAccountName" . }}"
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/scalyr-agent/templates/serviceaccount.yaml
+++ b/charts/scalyr-agent/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs) }}
+{{- if and (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) (.Values.serviceAccount.create) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/scalyr-agent/templates/serviceaccount.yaml
+++ b/charts/scalyr-agent/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "scalyr-helm.fullname" . }}-sa
+  name: {{ include "scalyr-helm.serviceAccountName" . }}
   labels:
     {{- include "scalyr-helm.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -148,6 +148,7 @@ affinity: {}
 
 # Values relevant to ServiceAccount
 serviceAccount:
+  create: true
   # serviceAccount.annotations -- optional arbitrary service account annotations
   annotations: {}
 

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -148,7 +148,11 @@ affinity: {}
 
 # Values relevant to ServiceAccount
 serviceAccount:
+  # create -- Auto-create the serviceAccount, clusterRole, and clusterRoleBinding.
+  # If false the user must provide their own and set the serviceAccount.nameOverride property
   create: true
+  # nameOverride -- Sets the name for the serviceAccount. Defaults to: {{"scalyr-helm.fullname"}}-sa
+  nameOverride: ""
   # serviceAccount.annotations -- optional arbitrary service account annotations
   annotations: {}
 


### PR DESCRIPTION
This PR adds support for setting two new values:

* `serviceAccount.create: false`
* `serviceAccount.nameOverride: name-goes-here`

My original problem was that I wanted to integrate scalyr w/ Argo Rollouts, and that required a permission change to support the `rollout` object.  I used a wrapper chart to create a new SA / CR / CRB with the appropriate permissions.