### PR TITLE
DSET-3651 Add permissions for argo-rollout to scalyr-agent ClusterRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-agent-2/blob/release/CHANGELOG.md
 
+## 0.2.31
+
+- Update ClusterRole to allow interrogation of Argo Rollout resources.
+
 ## 0.2.30
 
 - Update chart for DataSet agent v2.1.40 release.

--- a/charts/scalyr-agent/templates/cluster-role.yaml
+++ b/charts/scalyr-agent/templates/cluster-role.yaml
@@ -60,6 +60,13 @@ rules:
       - "nodes/proxy"
     verbs:
       - "get"
+  - apiGroups:
+      - "argoproj.io"
+    resources:
+      - "rollouts"
+    verbs:
+      - "get"
+      - "list"
   - nonResourceURLs:
       - "/metrics"
     verbs:


### PR DESCRIPTION
Add permissions to query argo rollouts to scalyr-agent ClusterRole.

DSET-3651