### PR TITLE
Prototype for using raw SCALYR_API_KEY environment variable value as-is (e.g. kube-secrets-init use case)

### DIFF
--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -226,6 +226,173 @@ jobs:
           steps: ${{ toJson(steps) }}
           channel: '#cloud-tech'
 
+  # Here we test the scenario where an raw apiKey chart value is used for SCALYR_API_KEY pod
+  # environment variable. This is to support the use cases like kube-secrets-init where
+  # the raw value contains reference to the secret which is replaced by external operator.
+  # Keep in mind that we only store raw api key itself in the secret for testing purposes,
+  # this is a bad practice and should never be used in real life.
+  daemonset_controller_type_raw_api_key_secret_value:
+    name: Daemonset - raw secret - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
+    runs-on: ubuntu-latest
+
+    needs: pre_job
+    timeout-minutes: 15
+    # NOTE: We always want to run job on main branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version:
+          - 'v1.24.3'
+        image_type:
+          - "buster"
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Set up Chart Testing Environment and Kubernetes Cluster
+        uses: ./.github/actions/setup-chart-testing-environment/
+        with:
+          k8s_version: "${{ matrix.k8s_version }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Scalyr Tool
+        uses: ./.github/actions/install-scalyr-tool/
+
+      - name: Install Helm Chart
+        uses: ./.github/actions/install-helm-chart
+        with:
+          scalyr_api_key: "${{ secrets.SCALYR_WRITE_API_KEY_US }}"
+          values_file_path: "ci/daemonset-agent-values-raw-secret.yaml"
+          image_type: "${{ matrix.image_type }}"
+
+      - name: Describe Pod
+        run: |
+          set -e
+
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME}
+
+          # Verify test volume defined using chart volumes and volumeMounts value is there
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "/test-volume from test-volume (rw)"
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "test-volume:"
+
+          # Verify that secret hasn't been created since useRawSecretEnvValue is used
+          kubectl get secret 
+          kubectl get secret | grep -vz scalyr-api-key
+
+      - name: Verify Logs are Ingested
+        env:
+          scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"
+          SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
+        run: |
+          # Verify agent and kubernetes monitor has been started
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Starting scalyr agent..."'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "No checkpoints were found. All logs will be copied starting at their current end"'
+
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Cluster name detected, enabling k8s metric reporting"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "kubernetes_monitor parameters: "'
+
+          # Verify Kubernetes metrics are beeing ingested
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-deployment=\"scalyr-agent\""'
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/main' || github.head_ref == 'main') }}
+        uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f  # v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'
+
+  deployment_controller_type_raw_api_key_secret_value:
+    name: Deployment - raw secret - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
+    runs-on: ubuntu-latest
+
+    needs: pre_job
+    timeout-minutes: 15
+    # NOTE: We always want to run job on main branch
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version:
+          - 'v1.24.3'
+        image_type:
+          - "buster"
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Set up Chart Testing Environment and Kubernetes Cluster
+        uses: ./.github/actions/setup-chart-testing-environment/
+        with:
+          k8s_version: "${{ matrix.k8s_version }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Scalyr Tool
+        uses: ./.github/actions/install-scalyr-tool/
+
+      - name: Install Helm Chart
+        uses: ./.github/actions/install-helm-chart
+        with:
+          scalyr_api_key: "${{ secrets.SCALYR_WRITE_API_KEY_US }}"
+          values_file_path: "ci/deployment-agent-values-raw-secret.yaml"
+          image_type: "${{ matrix.image_type }}"
+
+      - name: Describe Pod
+        run: |
+          set -e
+
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME}
+
+          # Verify test volume defined using chart volumes and volumeMounts value is there
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "/test-volume from test-volume (rw)"
+          kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "test-volume:"
+
+          # Verify that secret hasn't been created since useRawSecretEnvValue is used
+          kubectl get secret 
+          kubectl get secret | grep -vz scalyr-api-key
+
+      - name: Verify Logs are Ingested
+        env:
+          scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"
+          SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
+        run: |
+          # Verify agent and kubernetes monitor has been started
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Starting scalyr agent..."'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "No checkpoints were found. All logs will be copied starting at their current end"'
+
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "Cluster name detected, enabling k8s metric reporting"'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "kubernetes_monitor parameters: "'
+
+          # Verify Kubernetes metrics are beeing ingested
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-deployment=\"scalyr-agent\""'
+
+      - name: Notify Slack on Failure
+        # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull
+        # requests and that's why we need this special conditional and check for github.head_ref in
+        # case of PRs
+        if: ${{ failure() && (github.ref == 'refs/heads/main' || github.head_ref == 'main') }}
+        uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f  # v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#cloud-tech'
+
   daemonset_controller_type_k8s_explorer_no_deps:
     # In this workflow we manually install node exporter and kube state metrics exporter dependency
     name: K8s Explorer - no deps - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -280,7 +280,7 @@ jobs:
           kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "/test-volume from test-volume (rw)"
           kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "test-volume:"
 
-          # Verify that secret hasn't been created since useRawSecretEnvValue is used
+          # Verify that secret hasn't been created since useRawApiKeyEnvValue is used
           kubectl get secret 
           kubectl get secret | grep -vz scalyr-api-key
 
@@ -361,7 +361,7 @@ jobs:
           kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "/test-volume from test-volume (rw)"
           kubectl describe pod ${SCALYR_AGENT_POD_NAME} | grep "test-volume:"
 
-          # Verify that secret hasn't been created since useRawSecretEnvValue is used
+          # Verify that secret hasn't been created since useRawApiKeyEnvValue is used
           kubectl get secret 
           kubectl get secret | grep -vz scalyr-api-key
 

--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -284,7 +284,7 @@ jobs:
           kubectl get secret 
           kubectl get secret | grep -vz scalyr-api-key
 
-      - name: Verify Logs are Ingested
+      - name: Verify Agent Logs are Ingested
         env:
           scalyr_readlog_token: "${{ secrets.SCALYR_READ_API_KEY_US }}"
           SCALYR_AGENT_POD_NAME: "${{ env.SCALYR_AGENT_POD_NAME }}"
@@ -297,7 +297,7 @@ jobs:
           ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/agent.log" attribute1="value1" "kubernetes_monitor parameters: "'
 
           # Verify Kubernetes metrics are beeing ingested
-          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-deployment=\"scalyr-agent\""'
+          ./ci/scripts/scalyr-query.sh '$serverHost="'${SCALYR_AGENT_POD_NAME}'" $logfile="/var/log/scalyr-agent-2/kubernetes_monitor.log" "k8s-daemon-set=\"scalyr-agent\""'
 
       - name: Notify Slack on Failure
         # NOTE: github.ref is set to pr ref (and not branch name, e.g. refs/pull/28/merge) for pull

--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -10,34 +10,28 @@ on:
     - cron: '0 4 * * *'
 
 permissions:
-  actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
 jobs:
-  # Special job which automatically cancels old runs for the same branch, prevents runs for the
-  # same file set which has already passed, etc.
-  pre_job:
-    name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
-        with:
-          cancel_others: 'true'
-          github_token: ${{ github.token }}
-
   TruffleHog:
     runs-on: ubuntu-latest
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref_name == 'main' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      # Special check which ensures that the clone performed above is not shallow. We need the
+      # complete git history for scanning to work correctly in all the situations. In some cases
+      # if a shallow clone is used, trufflehog won't not fail with an error, but it would simply
+      # not detect any files and that could be dangerous.
+      - name: Shallow repo check
+        run: |
+          if git rev-parse --is-shallow-repository | grep -q "true"; then
+            echo "Encountered a shallow repository, trufflehog may not work as expected!"
+            exit 1
+          fi
 
       - name: scan-pr
         uses: trufflesecurity/trufflehog@main
@@ -47,7 +41,6 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
-            --exclude-paths=${{ inputs.exclude-paths }}
 
       - name: scan-push
         uses: trufflesecurity/trufflehog@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
 
   When this value is set to true, corresponding ``Secret`` object is also not created.
 
-  This is can be used in deployments which utilize an operator / approach like kube-secrets-init
-  which directly replaces matching prefixed environment variable value with a secret value. For
-  more information on the use case and usage of this chart value, please refer to the README.md.
+  This value can be used in deployments which utilize an operator / tool like kube-secrets-init
+  which directly replaces matching prefixed environment variable value with a secret value.
+
+  For more information on the use case and usage of this chart value, please refer to the
+  README.md.
+  
+  #61 #64
 
 ## 0.2.32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-a
 
 ## 0.2.33
 
-- Add new ``useRawSecretEnvValue`` chart value. When this value is set to true (defaults to false),
+- Add new ``useRawApiKeyEnvValue`` chart value. When this value is set to true (defaults to false),
   ``scalyr.apiKey`` chart value is used as-is for the ``SCALYR_API_KEY`` pod environment variable.
 
   When this value is set to true, corresponding ``Secret`` object is also not created.
 
   This is can be used in deployments which utilize an operator / approach like kube-secrets-init
-  which directly replaces matching prefixed environment variable value with a secret value.
+  which directly replaces matching prefixed environment variable value with a secret value. For
+  more information on the use case and usage of this chart value, please refer to the README.md.
 
 ## 0.2.32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 For actual scalyr agent changelog, please see https://github.com/scalyr/scalyr-agent-2/blob/release/CHANGELOG.md
 
+## 0.2.33
+
+- Add new ``useRawSecretEnvValue`` chart value. When this value is set to true (defaults to false),
+  ``scalyr.apiKey`` chart value is used as-is for the ``SCALYR_API_KEY`` pod environment variable.
+
+  When this value is set to true, corresponding ``Secret`` object is also not created.
+
+  This is can be used in deployments which utilize an operator / approach like kube-secrets-init
+  which directly replaces matching prefixed environment variable value with a secret value.
+
 ## 0.2.32
 
 - Update chart for DataSet agent v2.2.3 release.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Here is an example excerpt chart configuration for such use case:
 ```yaml
 # Values relevant to ServiceAccount
 scalyr:
-  apiKey: gcp:secretmanager:projects/$PROJECT_ID/secrets/mydbpassword/versions/2
+  apiKey: gcp:secretmanager:projects/$PROJECT_ID/secrets/myscalyragentapikey/versions/2
 useRawApiKeyEnvValue: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ Example:
   ```
   This gives the pod permission to read the secret as defined in the IAM Policy. (Something in the cluster such as a MutatingWebhook will need to actually facilitate the secret lookup)
 
+## Using raw value for "SCALYR_API_KEY" pod environment variable
+
+By default, ``scalyr.apiKey`` chart value is stored in a Kubernetes Secret and then this secret is
+referenced by the ``SCALYR_API_KEY`` pod environment variable.
+
+In some situations, you may want to define a raw value for this environment variable. An example of
+that is using a tool like ``kube-secrets-init`` which relies on environment variable being set to a
+special prefixed value which will eventually get replaced with the actual secret by the tool itself.
+
+Here is an example excerpt chart configuration for such use case:
+
+```yaml
+# Values relevant to ServiceAccount
+scalyr:
+  apiKey: gcp:secretmanager:projects/$PROJECT_ID/secrets/mydbpassword/versions/2
+useRawApiKeyEnvValue: true
+```
 
 ## Changelog
 

--- a/charts/scalyr-agent/Chart.yaml
+++ b/charts/scalyr-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scalyr-agent
 description: A Helm chart for deploying the Scalyr agent
 type: application
-version: 0.2.32
+version: 0.2.34
 appVersion: 2.2.3
 keywords:
   - scalyr

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -89,6 +89,9 @@ spec:
             - name: "SCALYR_SERVER"
               value: {{ .Values.scalyr.server }}
             - name: "SCALYR_API_KEY"
+              {{- if .Values.useRawSecretEnvValue }}
+              value: {{ .Values.apiKey }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.existingSecretRef }}
@@ -97,6 +100,7 @@ spec:
                   name: "{{ include "scalyr-helm.fullname" . }}-scalyr-api-key"
                   {{- end }}
                   key: "scalyr-api-key"
+              {{- end }}
             {{- if (or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) (.Values.scalyr.k8s.enableExplorer))  }}
             - name: "SCALYR_K8S_CLUSTER_NAME"
               value: "{{ .Values.scalyr.k8s.clusterName }}"

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -89,7 +89,7 @@ spec:
             - name: "SCALYR_SERVER"
               value: {{ .Values.scalyr.server }}
             - name: "SCALYR_API_KEY"
-              {{- if .Values.useRawSecretEnvValue }}
+              {{- if .Values.useRawApiKeyEnvValue }}
               value: {{ .Values.scalyr.apiKey }}
               {{- else }}
               valueFrom:

--- a/charts/scalyr-agent/templates/daemonset.yaml
+++ b/charts/scalyr-agent/templates/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
               value: {{ .Values.scalyr.server }}
             - name: "SCALYR_API_KEY"
               {{- if .Values.useRawSecretEnvValue }}
-              value: {{ .Values.apiKey }}
+              value: {{ .Values.scalyr.apiKey }}
               {{- else }}
               valueFrom:
                 secretKeyRef:

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: "SCALYR_SERVER"
               value: {{ .Values.scalyr.server }}
             - name: "SCALYR_API_KEY"
-              {{- if .Values.useRawSecretEnvValue }}
+              {{- if .Values.useRawApiKeyEnvValue }}
               value: {{ .Values.scalyr.apiKey }}
               {{- else }}
               valueFrom:

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
               value: {{ .Values.scalyr.server }}
             - name: "SCALYR_API_KEY"
               {{- if .Values.useRawSecretEnvValue }}
-              value: {{ .Values.apiKey }}
+              value: {{ .Values.scalyr.apiKey }}
               {{- else }}
               valueFrom:
                 secretKeyRef:

--- a/charts/scalyr-agent/templates/deployment.yaml
+++ b/charts/scalyr-agent/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
             - name: "SCALYR_SERVER"
               value: {{ .Values.scalyr.server }}
             - name: "SCALYR_API_KEY"
+              {{- if .Values.useRawSecretEnvValue }}
+              value: {{ .Values.apiKey }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.existingSecretRef }}
@@ -95,6 +98,7 @@ spec:
                   name: "{{ include "scalyr-helm.fullname" . }}-scalyr-api-key"
                   {{- end }}
                   key: "scalyr-api-key"
+              {{- end }}
             {{- if (or (or (.Values.scalyr.k8s.enableMetrics) (.Values.scalyr.k8s.enableLogs)) (.Values.scalyr.k8s.enableExplorer))  }}
             - name: "SCALYR_K8S_CLUSTER_NAME"
               value: "{{ .Values.scalyr.k8s.clusterName }}"

--- a/charts/scalyr-agent/templates/secret.yaml
+++ b/charts/scalyr-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not (.Values.useRawSecretEnvValue) }}
+{{- if not (.Values.useRawApiKeyEnvValue) }}
 {{- if eq .Values.existingSecretRef "" -}}
 {{- $name := .Values.scalyr.apiKey | required ".Values.scalyr.apiKey is required." -}}
 

--- a/charts/scalyr-agent/templates/secret.yaml
+++ b/charts/scalyr-agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.useRawSecretEnvValue) }}
 {{- if eq .Values.existingSecretRef "" -}}
 {{- $name := .Values.scalyr.apiKey | required ".Values.scalyr.apiKey is required." -}}
 
@@ -9,4 +10,5 @@ metadata:
   {{- include "scalyr-helm.labels" . | nindent 4 }}
 data:
   scalyr-api-key: {{ .Values.scalyr.apiKey | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -151,7 +151,7 @@ serviceAccount:
   # serviceAccount.annotations -- optional arbitrary service account annotations
   annotations: {}
 
-# useRawApiKeyEnvValue -- Set this to true if you want raw API key from "apiKey" chart value to be used for the SCALYR_API_KEY pod environment variable. This comes handy in situations where you don't want to use a secret (e.g. you utilize something like kube-secrets-init which directly replaces environment variable value with the actual secret).
+# useRawApiKeyEnvValue -- Set this to true if you want raw API key from "scalyr.apiKey" chart value to be used for the SCALYR_API_KEY pod environment variable. This comes handy in situations where you don't want to use a secret (e.g. you utilize something like kube-secrets-init which directly replaces environment variable value with the actual secret).
 useRawApiKeyEnvValue: false
 
 # existingSecretRef -- Use this value if the Scalyr API key is already stored in a Kubernetes secret that was created by an external secrets operator or similar.

--- a/charts/scalyr-agent/values.yaml
+++ b/charts/scalyr-agent/values.yaml
@@ -28,7 +28,7 @@ volumeMounts: {}
 scalyr:
   # scalyr.server -- The Scalyr server to send logs to. Use eu.scalyr.com for EU
   server: "agent.scalyr.com"
-  # scalyr.apiKey -- The Scalyr API key to use
+  # scalyr.apiKey -- The Scalyr API key to use. Can also be used in combination with "useRawApiKeyEnvValue" when using something like kube-secrets-init. In that case, this should be a reference to the secret which will be replaced by kube-secrets-init.
   apiKey: ""
   # scalyr.debugLevel -- Set this to number between 1 and 5 (inclusive - 1 being least verbose and
   # 5 being most verbose) to enable additional debug logging into agent_debug.log file.
@@ -150,6 +150,9 @@ affinity: {}
 serviceAccount:
   # serviceAccount.annotations -- optional arbitrary service account annotations
   annotations: {}
+
+# useRawApiKeyEnvValue -- Set this to true if you want raw API key from "apiKey" chart value to be used for the SCALYR_API_KEY pod environment variable. This comes handy in situations where you don't want to use a secret (e.g. you utilize something like kube-secrets-init which directly replaces environment variable value with the actual secret).
+useRawApiKeyEnvValue: false
 
 # existingSecretRef -- Use this value if the Scalyr API key is already stored in a Kubernetes secret that was created by an external secrets operator or similar.
 existingSecretRef: ""

--- a/ci/daemonset-agent-values-raw-secret.yaml
+++ b/ci/daemonset-agent-values-raw-secret.yaml
@@ -17,7 +17,7 @@ scalyr:
     # ci/examples/agent.d/test-config.json
     test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
 
-useRawSecretEnvValue: true
+useRawApiKeyEnvValue: true
 
 volumes:
   - name: test-volume

--- a/ci/daemonset-agent-values-raw-secret.yaml
+++ b/ci/daemonset-agent-values-raw-secret.yaml
@@ -1,0 +1,31 @@
+# Values file used by end to end tests
+controllerType: "daemonset"
+podLabels:
+  test: "true"
+extraEnvVars:
+  - name: SCALYR_FOO_1
+    value: "foo1"
+  - name: SCALYR_BAR_2
+    value: "bar2"
+scalyr:
+  apiKey: "REPLACE_ME"
+  k8s:
+    clusterName: "k8s-explorer-e2e-tests"
+    verifyKubeletQueries: false
+  base64Config: true
+  config:
+    # ci/examples/agent.d/test-config.json
+    test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
+
+useRawSecretEnvValue: true
+
+volumes:
+  - name: test-volume
+    emptyDir: {}
+
+volumeMounts:
+  - mountPath: /test-volume
+    name: test-volume
+
+image:
+  distro: "IMAGE_TYPE"

--- a/ci/deployment-agent-values-raw-secret.yaml
+++ b/ci/deployment-agent-values-raw-secret.yaml
@@ -12,7 +12,7 @@ scalyr:
     # ci/examples/agent.d/test-config.json
     test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
 
-useRawSecretEnvValue: true
+useRawApiKeyEnvValue: true
 
 volumes:
   - name: test-volume

--- a/ci/deployment-agent-values-raw-secret.yaml
+++ b/ci/deployment-agent-values-raw-secret.yaml
@@ -1,0 +1,23 @@
+# Values file used by end to end tests
+controllerType: "deployment"
+podLabels:
+  test: "true"
+scalyr:
+  apiKey: "REPLACE_ME"
+  k8s:
+    clusterName: "k8s-explorer-e2e-tests"
+    verifyKubeletQueries: false
+  base64Config: true
+  config:
+    # ci/examples/agent.d/test-config.json
+    test-config.json: e3NlcnZlcl9hdHRyaWJ1dGVzOiB7YXR0cmlidXRlMTogInZhbHVlMSIsYXR0cmlidXRlMjogInZhbHVlMiIsfSx9
+
+useRawSecretEnvValue: true
+
+volumes:
+  - name: test-volume
+    emptyDir: {}
+
+volumeMounts:
+  - mountPath: /test-volume
+    name: test-volume


### PR DESCRIPTION
This pull request is a quick prototype for the use case described in #63.

It introduces new a ``useRawApiKeyEnvValue`` chart value. When this value is set to ``true``, ``scalyr.apiKey`` chart value will be used as-is for the ``SCALYR_API_KEY`` pod environment variable (aka secret won't be created and used).

This may come handy in situations where user uses something like kube-cloud-init which doesn't rely on `Secret` `CRD`, but it works by replacing references in the environment variable values directly with the actual secrets.

## TODO

- [x] Tests
- [x] Documentation (document this value and use case for it)
- [x] Changelog entry