### PR TITLE
[DPDV-2870] Migrate from skip-duplicate-actions GHA action to native GHA concurrency functionality

### DIFF
--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -17,32 +17,19 @@ on:
     - cron: '0 4 * * *'
 
 permissions:
-  actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
-jobs:
-  # Special job which automatically cancels old runs for the same branch, prevents runs for the
-  # same file set which has already passed, etc.
-  pre_job:
-    name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281  # v4.0.0
-        with:
-          cancel_others: 'true'
-          github_token: ${{ github.token }}
+# We don't want to cancel any redundant runs on main so we use run_id when head_ref is
+# not available
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
+jobs:
   daemonset_controller_type:
     name: Daemonset - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
     timeout-minutes: 15
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -151,11 +138,7 @@ jobs:
   deployment_controller_type:
     name: Deployment - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
     timeout-minutes: 15
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -234,11 +217,7 @@ jobs:
   daemonset_controller_type_raw_api_key_secret_value:
     name: Daemonset - raw secret - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
     timeout-minutes: 15
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -315,11 +294,7 @@ jobs:
   deployment_controller_type_raw_api_key_secret_value:
     name: Deployment - raw secret - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
     timeout-minutes: 15
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -397,11 +372,7 @@ jobs:
     # In this workflow we manually install node exporter and kube state metrics exporter dependency
     name: K8s Explorer - no deps - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
     timeout-minutes: 15
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -515,11 +486,7 @@ jobs:
     # In this workflow we use helm chart functionality to install the dependencies
     name: K8s Explorer - deps - k8s ${{ matrix.k8s_version }} - ${{ matrix.image_type }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
     timeout-minutes: 15
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -13,31 +13,18 @@ on:
     - cron: '0 4 * * *'
 
 permissions:
-  actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
-jobs:
-  # Special job which automatically cancels old runs for the same branch, prevents runs for the
-  # same file set which has already passed, etc.
-  pre_job:
-    name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281  # v4.0.0
-        with:
-          cancel_others: 'true'
-          github_token: ${{ github.token }}
+# We don't want to cancel any redundant runs on main so we use run_id when head_ref is
+# not available
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
+jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-
-    needs: pre_job
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout Repository
@@ -72,10 +59,6 @@ jobs:
   helm_install:
     name: Helm Install - k8s ${{ matrix.k8s_version }}
     runs-on: ubuntu-latest
-
-    needs: pre_job
-    # NOTE: We always want to run job on main branch
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request updates the workflows to utilize native GHA "concurrency" functionality instead of relying on marketplace `skip-duplicate-jobs` action.

Utilizing native functionality allows us to simplify the workflow and also reduce the permissions the workflow requires to run (we don't need `actions: write` permission anymore).